### PR TITLE
feat: added optional properties to Category and Product types

### DIFF
--- a/src/optional-properties.ts
+++ b/src/optional-properties.ts
@@ -1,0 +1,17 @@
+type ID = string | number;
+
+type Category = {
+	id: ID;
+	name: string;
+	description?: string
+};
+
+type Product = {
+	id: ID;
+	name: string;
+	price: number;
+	description?: string
+};
+
+export { Category, ID, Product };
+

--- a/tests/optional-properties.test.ts
+++ b/tests/optional-properties.test.ts
@@ -1,0 +1,20 @@
+import { Category, Product } from "../src/optional-properties"
+
+describe('optional properties', () => {
+	it('must support optional properties', () => {
+		const category: Category = {
+			id: 1,
+			name: "Laptop",
+			description: "blablabla" // but optional
+		}
+		const product: Product = {
+			id: "1",
+			name: "ThinkPad X1 Nano",
+			price: 15_000_000.00,
+			// we disable optional properties "description" here
+		}
+
+		console.log("category:", category)
+		console.log("product:", product)
+	})
+})


### PR DESCRIPTION
This commit adds optional properties to the Category and Product types, allowing for more flexibility when defining these objects.

The description property is now optional on both the Category and Product types. This allows for the creation of categories and products that do not have descriptions, which may be useful in some cases.
