### PR TITLE
feat(extending-interface): add support for extending interface

### DIFF
--- a/src/extending-interface.ts
+++ b/src/extending-interface.ts
@@ -1,0 +1,14 @@
+export enum Division {
+	A = "A",
+	B = "B"
+}
+
+export interface Employee {
+	id: string,
+	name: string,
+	division: Division,
+}
+
+export interface Manager extends Employee {
+	numOfEmployees: number,
+}

--- a/tests/extending-interface.test.ts
+++ b/tests/extending-interface.test.ts
@@ -1,0 +1,22 @@
+import { Division, Employee, Manager } from "../src/extending-interface"
+
+describe('extending interface', () => {
+	it('must support extending interface', () => {
+		const employee: Employee = {
+			id: "1",
+			name: "A",
+			division: Division.A,
+		}
+
+		console.log('employee:', employee)
+
+		const manager: Manager = {
+			id: '2',
+			name: "B",
+			division: Division.B,
+			numOfEmployees: 1,
+		}
+
+		console.log('manager:', manager)
+	})
+})


### PR DESCRIPTION
Adds support for extending interfaces. This allows us to create new interfaces that inherit properties and methods from existing interfaces.

This feature is useful for creating hierarchies of objects that share common properties and methods, but also have unique properties and methods. For example, we could create an Employee interface with properties like name and id, and then create a Manager interface that extends the Employee interface and adds properties like numOfEmployees.
