### PR TITLE
feat: add function in interface

### DIFF
--- a/src/function-in-interface.ts
+++ b/src/function-in-interface.ts
@@ -1,0 +1,4 @@
+export interface Person {
+	name: string,
+	sayHello(name: string): string
+}

--- a/tests/function-in-interface.test.ts
+++ b/tests/function-in-interface.test.ts
@@ -1,0 +1,14 @@
+import { Person } from "../src/function-in-interface"
+
+describe('function in interface', () => {
+	it('must support function in interface', () => {
+		const person: Person = {
+			name: "irda",
+			sayHello: function (name: string) {
+				return `Hello ${name}, my name is ${this.name}`
+			}
+		}
+
+		expect(person.sayHello("haha")).toBe("Hello haha, my name is irda")
+	})
+})


### PR DESCRIPTION
Adds a new feature that allows functions to be defined in interfaces.

This allows for more flexible and extensible code, as functions can now be passed around as objects and used in a variety of ways.

BREAKING CHANGE: The syntax for defining functions in interfaces has changed. Functions must now be defined using the `function` keyword, followed by the function name and parameters.
