### PR TITLE
feat: support intersection type

### DIFF
--- a/src/intersection-type.ts
+++ b/src/intersection-type.ts
@@ -1,0 +1,9 @@
+export interface HasID {
+	id: number
+}
+
+export interface HasName {
+	name: string
+}
+
+export type Domain = HasID & HasName

--- a/tests/intersection-type.test.ts
+++ b/tests/intersection-type.test.ts
@@ -1,0 +1,12 @@
+import { Domain } from "../src/intersection-type"
+
+describe('intersection type', () => {
+	it('must support intersection type', () => {
+		const domain: Domain = {
+			id: 1,
+			name: "irda"
+		}
+
+		console.log('domain:', domain)
+	})
+})


### PR DESCRIPTION
Adds support for intersection types.

Intersection types allow us to create new types from existing types.
This can be useful for creating types that represent objects that have multiple different properties.
For example, we can create a type that represents an object that has both an ID and a name:

```typescript
type Domain = HasID & HasName;
```

This type would require its instances to have both an id and a name.
