### PR TITLE
feat(tests): add tests for overloading function

### DIFF
--- a/tests/overloading-function.test.ts
+++ b/tests/overloading-function.test.ts
@@ -1,0 +1,16 @@
+describe('overloading function', () => {
+	it('must support overloading function', () => {
+		function callMe(me: string): string;
+		function callMe(me: number): number;
+		function callMe(me: any) {
+			if (typeof me === "string") {
+				return me
+			} else if (typeof me === "number") {
+				return me
+			}
+		}
+
+		expect(callMe("irda")).toBe("irda")
+		expect(callMe(22)).toBe(22)
+	})
+})


### PR DESCRIPTION
This commit introduces a new test case for overloading functions.

The `callMe` function is overloaded to take either a string or a number argument and return the same value. The test case verifies that the function returns the correct value for both types of arguments.
