### PR TITLE
feat: add support for function as parameter

### DIFF
--- a/tests/function-as-parameter.test.ts
+++ b/tests/function-as-parameter.test.ts
@@ -1,0 +1,21 @@
+describe('function as parameter', () => {
+	it('must support function as parameter', () => {
+		const sayHello = (name: string, filters?: ((name: string) => string)[]): string => {
+			if (filters !== undefined) {
+				for (const filter of filters) {
+					name = filter(name)
+				}
+			}
+			return `Hello ${name}`
+		}
+
+		expect(sayHello("irda")).toBe("Hello irda")
+
+		function toUpper(name: string): string {
+			return name.toUpperCase()
+		}
+
+		expect(sayHello("iRdA", [toUpper, (name: string): string => name.toLowerCase()])).toBe("Hello irda")
+		expect(sayHello("iRdA", [(name: string): string => name.toLowerCase(), toUpper])).toBe("Hello IRDA")
+	})
+})


### PR DESCRIPTION
Adds support for passing functions as parameters to the `sayHello` function. This allows for more flexibility in how the name is formatted before being returned.
